### PR TITLE
refactor(server): 移除上傳目錄的靜態文件服務

### DIFF
--- a/server.js
+++ b/server.js
@@ -155,7 +155,7 @@ function fileToGenerativePart(filePath, mimeType) {
 app.use(express.urlencoded({ extended: true })); // Parse URL-encoded bodies
 app.use(express.json()); // Parse JSON bodies
 app.use(express.static(path.join(__dirname))); // Serve static files from root (for index.html)
-app.use('/uploads', express.static(UPLOADS_DIR)); // Serve uploaded images (if needed for direct access)
+// app.use('/uploads', express.static(UPLOADS_DIR)); // Serve uploaded images (if needed for direct access) - Removed as GCS is used
 
 app.get('/', (req, res) => {
     res.sendFile(path.join(__dirname, 'index.html'));


### PR DESCRIPTION
由於已改用GCS存儲上傳文件，不再需要本地靜態文件服務